### PR TITLE
Separate notifications into namespaces by URL

### DIFF
--- a/main.go
+++ b/main.go
@@ -61,12 +61,12 @@ func ActionMain(c *cli.Context) {
 
 type Message struct {
 	Topic string
-	Body   []byte
+	Body  []byte
 }
 
 type Listener struct {
 	Topic string
-	c      chan []byte
+	c     chan []byte
 }
 
 type Hookbot struct {

--- a/main.go
+++ b/main.go
@@ -12,7 +12,7 @@ import (
 	"net/http"
 	"net/url"
 	"os"
-	"strings"
+	"regexp"
 	"time"
 
 	"github.com/codegangsta/cli"
@@ -194,11 +194,15 @@ func (h *Hookbot) KeyChecker(wrapped http.Handler) http.HandlerFunc {
 	}
 }
 
+// The topic is everything after the "/pub/" or "/sub/"
+var TopicRE *regexp.Regexp = regexp.MustCompile("/[^/]+/(.*)")
+
 func Topic(url *url.URL) string {
-	// The topic is everything after the "/pub/" or "/sub/"
-	p := strings.SplitN(url.Path, "/", 3)
-	topic := p[2]
-        return topic
+	m := TopicRE.FindStringSubmatch(url.Path)
+	if m == nil {
+		return ""
+	}
+	return m[1]
 }
 
 func (h *Hookbot) ServePublish(w http.ResponseWriter, r *http.Request) {


### PR DESCRIPTION
The new types `Message` and `Listener` have been created which add a `Suffix` to what was previous a bare `[]byte` and a `chan []byte` respectively.