### PR TITLE
Improvements to make-tokens

### DIFF
--- a/main.go
+++ b/main.go
@@ -40,9 +40,10 @@ func main() {
 			},
 		},
 		{
-			Name:   "make-token",
-			Usage:  "given a URI, generate a token",
-			Action: ActionMakeToken,
+			Name:    "make-tokens",
+			Aliases: []string{"t"},
+			Usage:   "given a list of URIs, generate tokens one per line",
+			Action:  ActionMakeTokens,
 		},
 	}
 
@@ -62,15 +63,16 @@ func MustGetKeysFromEnv() (string, string) {
 	return key, github_secret
 }
 
-func ActionMakeToken(c *cli.Context) {
+func ActionMakeTokens(c *cli.Context) {
 	key, _ := MustGetKeysFromEnv()
-	if len(c.Args()) != 1 {
+	if len(c.Args()) < 1 {
 		cli.ShowSubcommandHelp(c)
 		os.Exit(1)
 	}
 
-	url := c.Args().First()
-	fmt.Println(Sha1HMAC(key, url))
+	for _, arg := range c.Args() {
+		fmt.Println(Sha1HMAC(key, arg))
+	}
 }
 
 func ActionServe(c *cli.Context) {

--- a/main.go
+++ b/main.go
@@ -40,18 +40,9 @@ func main() {
 			},
 		},
 		{
-			Name:  "make-token",
-			Usage: "given a URI, generate a token",
-			Action: func(c *cli.Context) {
-				key, _ := MustGetKeysFromEnv()
-				if len(c.Args()) != 1 {
-					cli.ShowSubcommandHelp(c)
-					os.Exit(1)
-				}
-
-				url := c.Args().First()
-				fmt.Println(Sha1HMAC(key, url))
-			},
+			Name:   "make-token",
+			Usage:  "given a URI, generate a token",
+			Action: ActionMakeToken,
 		},
 	}
 
@@ -69,6 +60,17 @@ func MustGetKeysFromEnv() (string, string) {
 	}
 
 	return key, github_secret
+}
+
+func ActionMakeToken(c *cli.Context) {
+	key, _ := MustGetKeysFromEnv()
+	if len(c.Args()) != 1 {
+		cli.ShowSubcommandHelp(c)
+		os.Exit(1)
+	}
+
+	url := c.Args().First()
+	fmt.Println(Sha1HMAC(key, url))
 }
 
 func ActionServe(c *cli.Context) {


### PR DESCRIPTION
* Renamed make-token to make-tokens
* Improved workflow for using tokens

Now, rather than having to make a token and then construct a URL with cumbersome editing of long tokens, the output is directly useful.

For example, now it's easy to do the following for testing:

```
export HOOKBOT_KEY=foo

hookbot serve

wscat $(hookbot make-tokens /sub/foo)
curl -d 'message' $(hookbot make-tokens /pub/foo)
```