### PR TITLE
Improvements to topics

### DIFF
--- a/auth_test.go
+++ b/auth_test.go
@@ -81,8 +81,6 @@ func TestUnsafePub(t *testing.T) {
 
 	run := func(iteration int) {
 
-		w, r := MakeRequest("POST", "/unsafe/pub/", "MESSAGE")
-
 		var c chan []byte
 
 		func() {
@@ -93,12 +91,14 @@ func TestUnsafePub(t *testing.T) {
 			defer hookbot.Del(msgs)
 			c = msgs.c
 
-			hookbot.ServeHTTP(w, r)
-		}()
+			w, r := MakeRequest("POST", "/unsafe/pub/", "MESSAGE")
 
-		if w.Code != http.StatusOK {
-			t.Errorf("Status code != 200 (= %v)", w.Code)
-		}
+			hookbot.ServeHTTP(w, r)
+
+			if w.Code != http.StatusOK {
+				t.Errorf("Status code != 200 (= %v)", w.Code)
+			}
+		}()
 
 		// Message should have been delivered by the time we see
 		// hookbot.Shutdown().

--- a/topic_test.go
+++ b/topic_test.go
@@ -1,0 +1,60 @@
+package main
+
+import (
+	"encoding/json"
+	"testing"
+)
+
+func getBody(m []byte) (string, error) {
+	type Buf struct {
+		Body string
+	}
+
+	buf := Buf{}
+	err := json.Unmarshal(m, &buf)
+	if err != nil {
+		return "", err
+	}
+
+	return buf.Body, nil
+}
+
+// Ensure that messages are delivered to the intended topics.
+// Deliver two messages to two different topics and check they arrive.
+func TestTopicsIndependent(t *testing.T) {
+
+	var c1, c2 chan []byte
+
+	func() {
+		hookbot := NewHookbot(TEST_KEY, TEST_GITHUB_SECRET)
+		defer hookbot.Shutdown()
+
+		msgsC1 := hookbot.Add("/unsafe/1")
+		msgsC2 := hookbot.Add("/unsafe/2")
+		defer hookbot.Del(msgsC1)
+		defer hookbot.Del(msgsC2)
+
+		c1, c2 = msgsC1.c, msgsC2.c
+
+		hookbot.ServeHTTP(MakeRequest("POST", "/unsafe/pub/1", "MESSAGE 1"))
+		hookbot.ServeHTTP(MakeRequest("POST", "/unsafe/pub/2", "MESSAGE 2"))
+	}()
+
+	checkDelivered := func(c chan []byte, expected string) {
+		select {
+		case m := <-c:
+			body, err := getBody(m)
+			if err != nil {
+				t.Fatalf("Failed to decode body: %v (%q)", err, m)
+			}
+			if body != expected {
+				t.Errorf("m != %s (=%q)", expected, body)
+			}
+		default:
+			t.Fatalf("Message not delivered correctly: %q", expected)
+		}
+	}
+
+	checkDelivered(c1, "MESSAGE 1")
+	checkDelivered(c2, "MESSAGE 2")
+}


### PR DESCRIPTION
* Implement selective topic strobing via map rather than comparison for every listener
* Add test that topics are working correctly
* (maybe): make topics hierarchical

On the last point, for example, you can subscribe to everything under github scraperwiki via:

`/sub/github.com/scraperwiki/`