### PR TITLE
Significantly reduce memory consumption

### DIFF
--- a/main.go
+++ b/main.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"log"
 	"net/http"
+	_ "net/http/pprof"
 	"net/url"
 	"os"
 	"regexp"

--- a/pkg/hookbot/auth_test.go
+++ b/pkg/hookbot/auth_test.go
@@ -88,7 +88,6 @@ func TestUnsafePub(t *testing.T) {
 			defer hookbot.Shutdown()
 
 			msgs := hookbot.Add("/unsafe/")
-			defer hookbot.Del(msgs)
 			c = msgs.c
 
 			w, r := MakeRequest("POST", "/unsafe/pub/", "MESSAGE")

--- a/pkg/hookbot/hookbot.go
+++ b/pkg/hookbot/hookbot.go
@@ -170,6 +170,11 @@ func (h *Hookbot) Loop() {
 	cMessageListener := make(chan MessageListener, 1000)
 	defer close(cMessageListener)
 
+	// Wait for the cMessageListeners goroutine to finish before closing
+	// cMessageListener
+	var wgMessageListeners sync.WaitGroup
+	defer wgMessageListeners.Wait()
+
 	cMessageListeners := make(chan MessageListeners, 100)
 	defer close(cMessageListeners)
 
@@ -182,9 +187,9 @@ func (h *Hookbot) Loop() {
 		}()
 	}
 
-	h.wg.Add(1)
+	wgMessageListeners.Add(1)
 	go func() {
-		defer h.wg.Done()
+		defer wgMessageListeners.Done()
 
 		// Fanout `cMessageListeners` onto available `TimeoutSendWorker`s
 		for lms := range cMessageListeners {

--- a/pkg/hookbot/router.go
+++ b/pkg/hookbot/router.go
@@ -9,7 +9,7 @@ import (
 type Router interface {
 	Name() string
 	Topics() []string
-	Route(in Message, publish func(Message))
+	Route(in Message, publish func(Message) bool)
 }
 
 var availableRouters []Router

--- a/pkg/hookbot/topic_test.go
+++ b/pkg/hookbot/topic_test.go
@@ -16,8 +16,6 @@ func TestTopicsIndependent(t *testing.T) {
 
 		msgsC1 := hookbot.Add("/unsafe/1")
 		msgsC2 := hookbot.Add("/unsafe/2")
-		defer hookbot.Del(msgsC1)
-		defer hookbot.Del(msgsC2)
 
 		c1, c2 = msgsC1.c, msgsC2.c
 
@@ -51,8 +49,6 @@ func TestTopicsRecursive(t *testing.T) {
 
 		msgsC1 := hookbot.Add("/unsafe/foo/?recursive")
 		msgsC2 := hookbot.Add("/unsafe/foo/bar")
-		defer hookbot.Del(msgsC1)
-		defer hookbot.Del(msgsC2)
 
 		c1, c2 = msgsC1.c, msgsC2.c
 
@@ -94,8 +90,6 @@ func TestTopicsNotRecursive(t *testing.T) {
 
 		msgsC1 := hookbot.Add("/unsafe/foo/")
 		msgsC2 := hookbot.Add("/unsafe/foo/bar")
-		defer hookbot.Del(msgsC1)
-		defer hookbot.Del(msgsC2)
 
 		c1, c2 = msgsC1.c, msgsC2.c
 

--- a/pkg/listen/listen.go
+++ b/pkg/listen/listen.go
@@ -72,7 +72,7 @@ func Watch(
 
 		for {
 			select {
-			case <-time.After(20 * time.Second):
+			case <-time.After(15*time.Second + Jitter(5)):
 				log.Println("Ping")
 				conn.SetWriteDeadline(time.Now().Add(10 * time.Second))
 				err := conn.WriteMessage(websocket.PingMessage, []byte{})
@@ -180,7 +180,7 @@ func RetryingWatch(
 
 		retry:
 			log.Printf("Connection failed. Retrying in 5 seconds.")
-			time.Sleep(5*time.Second + Jitter())
+			time.Sleep(5*time.Second + Jitter(1))
 		}
 	}()
 
@@ -188,6 +188,7 @@ func RetryingWatch(
 }
 
 // Return a random duration from -1s to +1s
-func Jitter() time.Duration {
-	return time.Duration(rand.Intn(2*int(time.Second))) - 1*time.Second
+func Jitter(mul int) time.Duration {
+	m := time.Duration(mul)
+	return time.Duration(rand.Intn(int(m*2*time.Second))) - m*1*time.Second
 }

--- a/pkg/router/github/github.go
+++ b/pkg/router/github/github.go
@@ -208,7 +208,7 @@ func (r *Router) Topics() []string {
 	return []string{"/unsafe/github.com/?recursive"}
 }
 
-func (r *Router) Route(in hookbot.Message, publish func(hookbot.Message)) {
+func (r *Router) Route(in hookbot.Message, publish func(hookbot.Message) bool) {
 
 	log.Printf("route github: %q", in.Topic)
 
@@ -264,7 +264,8 @@ func (r *Router) Route(in hookbot.Message, publish func(hookbot.Message)) {
 	case "push":
 		topicFmt := "github.com/repo/%s/branch/%s"
 
-		publish(hookbot.Message{
+		// May fail
+		_ = publish(hookbot.Message{
 			Topic: fmt.Sprintf(topicFmt, repo, branch),
 			Body:  msgBytes,
 		})


### PR DESCRIPTION
This changeset significantly reduces the memory requirements and also
improves the behaviour with lagging receivers and dropped messages.

In the worst case if all of the internal buffers somehow manage to get full,
POST'ing clients are now notified that their message couldn't be delivered,
too.

The main change here was to instead of spinning up a goroutine per sent message,
(just to have a timeout on that send), now there are worker goroutines which
handle a limited number of timeouts at once.

The performance is fairly significantly improved and has been measured to be
in excess of 70 msgs/sec to 1,000 clients before messages start getting dropped.

None of these changes were particularly needed for ScraperWiki's purposes, though
they did shake out a few bugs. They were mainly made so that I could do a fair
comparison with existing messaging systems.

For logging purposes, there is now a 1-minutely status line printing the number of connected clients along with the numbers of received, sent and dropped messages.