### PR TITLE
Avoid modifying caller's header value in Watch()

### DIFF
--- a/pkg/listen/listen.go
+++ b/pkg/listen/listen.go
@@ -37,9 +37,17 @@ func Watch(
 	}
 
 	if u.User != nil {
+		oldHeader := header
+
+		// Avoid modifying caller's headers
+		header = http.Header{}
+		for k, v := range oldHeader {
+			header[k] = v
+		}
+
 		userPassBytes := []byte(u.User.String() + ":")
 		token := base64.StdEncoding.EncodeToString(userPassBytes)
-		header.Add("Authorization", fmt.Sprintf("Basic %v", token))
+		header.Set("Authorization", fmt.Sprintf("Basic %v", token))
 		u.User = nil
 	}
 


### PR DESCRIPTION
This bug meant that users would keep adding more authorization headers
on every retry.