### PR TITLE
Display version number at command line

### DIFF
--- a/main.go
+++ b/main.go
@@ -19,6 +19,7 @@ func main() {
 	app := cli.NewApp()
 	app.Name = "hookbot"
 	app.Usage = "turn webhooks into websockets"
+	app.Version = "0.4"
 
 	app.Flags = []cli.Flag{
 		cli.StringFlag{


### PR DESCRIPTION
Would have found this useful today to see which version I had installed. Without this, it only shows `0.0.0`.