### PR TITLE
Prepend topic when ?recursive (NUL delimited)

### DIFF
--- a/pkg/hookbot/hookbot.go
+++ b/pkg/hookbot/hookbot.go
@@ -425,16 +425,15 @@ func (h *Hookbot) ServeSubscribe(conn *websocket.Conn, r *http.Request) {
 
 		conn.SetWriteDeadline(time.Now().Add(90 * time.Second))
 		_, isRecursive := recursive(topic)
-		err := error(nil)
+		msgBytes := []byte{}
 		if isRecursive {
-			topicMsg := []byte{}
-			topicMsg = append(topicMsg, message.Topic...)
-			topicMsg = append(topicMsg, '\x00')
-			topicMsg = append(topicMsg, message.Body...)
-			err = conn.WriteMessage(websocket.BinaryMessage, topicMsg)
+			msgBytes = append(msgBytes, message.Topic...)
+			msgBytes = append(msgBytes, '\x00')
+			msgBytes = append(msgBytes, message.Body...)
 		} else {
-			err = conn.WriteMessage(websocket.BinaryMessage, message.Body)
+			msgBytes = message.Body
 		}
+		err := conn.WriteMessage(websocket.BinaryMessage, msgBytes)
 		switch {
 		case err == io.EOF || IsConnectionClose(err):
 			return


### PR DESCRIPTION
Instead of just sending the body, also send the full topic, so
subscribers can make decisions based on the original topic.

The topic is ended by a NUL character. This was chosen
because `%00`s in URIs are recognised as being problematic and
"should be rejected if the application is not expecting ... raw data"