### PR TITLE
Add 401 Unauthorized response

### DIFF
--- a/pkg/hookbot/auth.go
+++ b/pkg/hookbot/auth.go
@@ -107,7 +107,8 @@ func (h *Hookbot) KeyChecker(wrapped http.Handler) http.HandlerFunc {
 		}
 
 		if !h.IsKeyOK(w, r) {
-			http.NotFound(w, r)
+			w.Header().Add("WWW-Authenticate", `Basic realm="hookbot"`)
+			http.Error(w, "401 Unauthorized", http.StatusUnauthorized)
 			return
 		}
 

--- a/pkg/hookbot/auth_test.go
+++ b/pkg/hookbot/auth_test.go
@@ -33,7 +33,7 @@ func TestAuthMissingFail(t *testing.T) {
 		hookbot.ServeHTTP(w, r)
 	}()
 
-	if w.Code != http.StatusNotFound {
+	if w.Code != http.StatusUnauthorized {
 		t.Errorf("Status code != 404 (= %v)", w.Code)
 	}
 }
@@ -52,7 +52,7 @@ func TestAuthInvalidSecret(t *testing.T) {
 		hookbot.ServeHTTP(w, r)
 	}()
 
-	if w.Code != http.StatusNotFound {
+	if w.Code != http.StatusUnauthorized {
 		t.Errorf("Status code != 404 (= %v)", w.Code)
 	}
 }


### PR DESCRIPTION
Resolves #24.

Now if you visit a /sub/ endpoint without the proper credentials, you
aways see 401, rather than 404.

This doesn't leak information, since all /sub/ endpoints always exist.