### PR TITLE
Add pub/sub auth-agnostic endpoints

### DIFF
--- a/pkg/listen/listen.go
+++ b/pkg/listen/listen.go
@@ -8,6 +8,7 @@ import (
 	"math/rand"
 	"net/http"
 	"net/url"
+	"strings"
 	"sync"
 	"time"
 
@@ -34,6 +35,16 @@ func Watch(
 	u, err := url.Parse(target)
 	if err != nil {
 		return nil, nil, err
+	}
+
+	if strings.HasPrefix(u.Path, "/xub/") {
+		u.Path = "/sub/" + strings.TrimPrefix(u.Path, "/xub/")
+		switch u.Scheme {
+		case "http":
+			u.Scheme = "ws"
+		case "https":
+			u.Scheme = "wss"
+		}
 	}
 
 	if u.User != nil {


### PR DESCRIPTION
This makes it possible to have a token which is valid for both pub and sub.

The mechanism is to make a token for `/foo` which is valid for both `/sub/foo` and `/sub/foo`.