### PR TITLE
Make URLs lacking /(pub|sub) both pub and sub

### DIFF
--- a/pkg/hookbot/hookbot.go
+++ b/pkg/hookbot/hookbot.go
@@ -88,11 +88,14 @@ func New(key string) *Hookbot {
 // If it is a POST request, it is publishing, otherwise it is subscribing.
 func (h *Hookbot) BothPubSub(pub, sub http.Handler) http.Handler {
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		if r.Method == "POST" {
+		switch r.Method {
+		case "POST":
 			pub.ServeHTTP(w, r)
-			return
+		case "GET":
+			sub.ServeHTTP(w, r)
+		default:
+			http.Error(w, "Not Implemented", http.StatusNotImplemented)
 		}
-		sub.ServeHTTP(w, r)
 	})
 }
 

--- a/pkg/hookbot/hookbot_test.go
+++ b/pkg/hookbot/hookbot_test.go
@@ -1,0 +1,34 @@
+package hookbot
+
+import "testing"
+
+// TestPubSub checks that messages are delivered when (pub|sub) is absent.
+func TestPubSub(t *testing.T) {
+	var messages chan Message
+
+	func() {
+		hookbot := New(TEST_KEY)
+		defer hookbot.Shutdown()
+
+		messages = hookbot.Add("test/topic").c
+
+		w, r := MakeRequest("POST", "/test/topic", "MESSAGE")
+		token := Sha1HMAC(TEST_KEY, "/test/topic")
+		r.SetBasicAuth(token, "")
+
+		hookbot.ServeHTTP(w, r)
+	}()
+
+	checkDelivered := func(c chan Message, expected string) {
+		select {
+		case m := <-c:
+			if string(m.Body) != expected {
+				t.Errorf("m != %s (=%q)", expected, string(m.Body))
+			}
+		default:
+			t.Fatalf("Message not delivered correctly: %q", expected)
+		}
+	}
+
+	checkDelivered(messages, "MESSAGE")
+}

--- a/pkg/listen/listen.go
+++ b/pkg/listen/listen.go
@@ -8,7 +8,6 @@ import (
 	"math/rand"
 	"net/http"
 	"net/url"
-	"strings"
 	"sync"
 	"time"
 
@@ -37,14 +36,12 @@ func Watch(
 		return nil, nil, err
 	}
 
-	if strings.HasPrefix(u.Path, "/xub/") {
-		u.Path = "/sub/" + strings.TrimPrefix(u.Path, "/xub/")
-		switch u.Scheme {
-		case "http":
-			u.Scheme = "ws"
-		case "https":
-			u.Scheme = "wss"
-		}
+	// If the scheme is http/https, map it to ws/wss.
+	switch u.Scheme {
+	case "http":
+		u.Scheme = "ws"
+	case "https":
+		u.Scheme = "wss"
 	}
 
 	if u.User != nil {


### PR DESCRIPTION
If /pub/ or /sub/ is specified, these are only allowed for publish or
subscribe.

In this new implementation, if they are missing, the URLs are allowed for both
publish and subscribe.